### PR TITLE
Remove registeredAt from User aggregate

### DIFF
--- a/src/Domain/User/User.php
+++ b/src/Domain/User/User.php
@@ -28,7 +28,6 @@ final class User implements EventSourcedAggregateInterface
     private UserId $id;
     private Email $email;
     private HashedPassword $password;
-    private \DateTimeImmutable $registeredAt;
 
     private function __construct()
     {
@@ -101,7 +100,6 @@ final class User implements EventSourcedAggregateInterface
         $this->id = UserId::fromString($event->id);
         $this->email = Email::fromString($event->email);
         $this->password = HashedPassword::fromHash($event->hashedPassword);
-        $this->registeredAt = $event->occurredAt;
     }
 
     private static function applyUserLoggedIn(UserLoggedIn $event): void


### PR DESCRIPTION
## Summary

Removes the `$registeredAt` property from the User aggregate while keeping it in the event and projection.

## Changes

- Removed `$registeredAt` property from User class
- Removed registeredAt assignment from `applyUserRegistered()` method
- Event and projection remain unchanged (still store/project the timestamp)

## Rationale

Per the project's "Behavior-Driven State" principle: every piece of state should be justified by behavior. The `registeredAt` timestamp is not used for any domain behavior, so it should not be stored on the aggregate itself. The timestamp is already captured in the `UserRegistered` event and projected to the read model for display/query purposes.

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)