### PR TITLE
Add date of birth and display name to user registration

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -113,6 +113,16 @@ services:
 
 when@test:
     services:
+        # Use MockClock for deterministic date/time in tests
+        Symfony\Component\Clock\MockClock:
+            public: true
+            arguments:
+                - '2025-12-12 12:00:00'
+                - 'UTC'
+
+        Psr\Clock\ClockInterface:
+            alias: Symfony\Component\Clock\MockClock
+
         # Make services public for testing
         MongoDB\Client:
             public: true

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -11,5 +11,6 @@ services:
         public: true
         arguments:
             $kernel: '@kernel'
+            $clock: '@Symfony\Component\Clock\MockClock'
             $mongoClient: '@MongoDB\Client'
             $mongoDatabase: '%env(MONGODB_DATABASE)%'

--- a/features/user/registration.feature
+++ b/features/user/registration.feature
@@ -4,23 +4,105 @@ Feature: User Registration
   I need to be able to register an account
 
   Scenario: Successfully register a new user
-    When I register with email "bob@example.com" and password "SecurePass123!"
+    When I register with:
+      | email       | bob@example.com |
+      | dateOfBirth | 1990-05-15      |
+      | displayName | Bob Bobbington  |
+      | password    | SecurePass123!  |
     Then I should be registered
 
   Scenario: Cannot register with duplicate email
-    Given a user exists with email "existing@example.com" and password "SecurePass123!"
-    When I register with email "existing@example.com" and password "AnotherPass456!"
+    Given a user exists with email "existing@example.com"
+    When I register with:
+      | email       | existing@example.com |
+      | dateOfBirth | 1990-05-15           |
+      | displayName | Another User         |
+      | password    | AnotherPass456!      |
     Then registration should fail due to duplicate email
 
   Scenario: Cannot register with duplicate email in different case
-    Given a user exists with email "test@example.com" and password "SecurePass123!"
-    When I register with email "TEST@EXAMPLE.COM" and password "AnotherPass456!"
+    Given a user exists with email "test@example.com"
+    When I register with:
+      | email       | TEST@EXAMPLE.COM |
+      | dateOfBirth | 1990-05-15       |
+      | displayName | Test User        |
+      | password    | AnotherPass456!  |
     Then registration should fail due to duplicate email
 
   Scenario: Cannot register with invalid email format
-    When I register with email "not-an-email" and password "SecurePass123!"
+    When I register with:
+      | email       | not-an-email   |
+      | dateOfBirth | 1990-05-15     |
+      | displayName | Bob Bobbington |
+      | password    | SecurePass123! |
     Then registration should fail due to invalid email format
 
   Scenario: Cannot register with password too short
-    When I register with email "bob@example.com" and password "short"
+    When I register with:
+      | email       | bob@example.com |
+      | dateOfBirth | 1990-05-15      |
+      | displayName | Bob Bobbington  |
+      | password    | short           |
     Then registration should fail due to invalid password
+
+  Scenario: Cannot register if under 18 years old
+    Given today's date is "December 12, 2025"
+    When I register with:
+      | email       | young@example.com |
+      | dateOfBirth | 2010-06-15        |
+      | displayName | Young User        |
+      | password    | SecurePass123!    |
+    Then registration should fail because user is under 18
+
+  Scenario: Can register if exactly 18 years old
+    Given today's date is "December 12, 2025"
+    When I register with:
+      | email       | adult@example.com |
+      | dateOfBirth | 2007-12-12        |
+      | displayName | Just Adult        |
+      | password    | SecurePass123!    |
+    Then I should be registered
+
+  Scenario: Cannot register with empty date of birth
+    When I register with:
+      | email       | bob@example.com |
+      | dateOfBirth |                 |
+      | displayName | Bob Bobbington  |
+      | password    | SecurePass123!  |
+    Then registration should fail due to invalid date of birth
+
+  Scenario: Cannot register with invalid date of birth format
+    When I register with:
+      | email       | bob@example.com |
+      | dateOfBirth | invalid-date    |
+      | displayName | Bob Bobbington  |
+      | password    | SecurePass123!  |
+    Then registration should fail due to invalid date of birth
+
+  Scenario: Cannot register with future date of birth
+    When I register with:
+      | email       | bob@example.com |
+      | dateOfBirth | 2030-01-01      |
+      | displayName | Bob Bobbington  |
+      | password    | SecurePass123!  |
+    Then registration should fail because date of birth is in the future
+
+  Scenario: Cannot register with empty display name
+    When I register with:
+      | email       | bob@example.com |
+      | dateOfBirth | 1990-05-15      |
+      | displayName |                 |
+      | password    | SecurePass123!  |
+    Then registration should fail due to invalid display name
+
+  Scenario: Cannot register with whitespace-only display name
+    When I register with a whitespace-only display name
+    Then registration should fail due to invalid display name
+
+  Scenario: Cannot register with display name exceeding 50 characters
+    When I register with:
+      | email       | bob@example.com                                                  |
+      | dateOfBirth | 1990-05-15                                                       |
+      | displayName | This is a very long display name that exceeds fifty characters!! |
+      | password    | SecurePass123!                                                   |
+    Then registration should fail due to invalid display name

--- a/src/Application/User/Command/RegisterUserCommand.php
+++ b/src/Application/User/Command/RegisterUserCommand.php
@@ -17,6 +17,8 @@ final readonly class RegisterUserCommand implements CommandInterface
     public function __construct(
         public string $userId,
         public string $email,
+        public string $dateOfBirth,
+        public string $displayName,
         public string $password,
     ) {
     }

--- a/src/Application/User/Command/RegisterUserHandler.php
+++ b/src/Application/User/Command/RegisterUserHandler.php
@@ -9,6 +9,8 @@ use App\Domain\Common\EventStore\EventStoreInterface;
 use App\Domain\User\Exception\CouldNotRegister;
 use App\Domain\User\User;
 use App\Domain\User\UserReadModelInterface;
+use App\Domain\User\ValueObject\DateOfBirth;
+use App\Domain\User\ValueObject\DisplayName;
 use App\Domain\User\ValueObject\Email;
 use App\Domain\User\ValueObject\PlainPassword;
 use App\Domain\User\ValueObject\UserId;
@@ -38,12 +40,16 @@ final readonly class RegisterUserHandler
         }
 
         $userId = UserId::fromString($command->userId);
+        $dateOfBirth = DateOfBirth::fromString($command->dateOfBirth);
+        $displayName = DisplayName::fromString($command->displayName);
         $plainPassword = PlainPassword::fromString($command->password);
         $hashedPassword = $this->passwordHasher->hash($plainPassword);
 
         $user = User::register(
             $userId,
             $email,
+            $dateOfBirth,
+            $displayName,
             $hashedPassword,
             $this->clock->now(),
         );

--- a/src/Domain/User/Event/UserRegistered.php
+++ b/src/Domain/User/Event/UserRegistered.php
@@ -14,6 +14,8 @@ final readonly class UserRegistered implements DomainEventInterface
     public function __construct(
         public string $id,
         public string $email,
+        public string $dateOfBirth,
+        public string $displayName,
         public string $hashedPassword,
         public \DateTimeImmutable $occurredAt,
     ) {

--- a/src/Domain/User/Exception/CouldNotRegister.php
+++ b/src/Domain/User/Exception/CouldNotRegister.php
@@ -8,8 +8,35 @@ use App\Domain\User\ValueObject\Email;
 
 final class CouldNotRegister extends \DomainException
 {
+    public readonly RegistrationFailureReason $reason;
+
+    private function __construct(string $message, RegistrationFailureReason $reason)
+    {
+        parent::__construct($message);
+        $this->reason = $reason;
+    }
+
     public static function becauseEmailIsAlreadyInUse(Email $email): self
     {
-        return new self(sprintf('Could not register: email "%s" is already in use.', $email->asString()));
+        return new self(
+            sprintf('Could not register: email "%s" is already in use.', $email->asString()),
+            RegistrationFailureReason::EmailAlreadyInUse,
+        );
+    }
+
+    public static function becauseUserIsTooYoung(int $age, int $minimumAge): self
+    {
+        return new self(
+            sprintf('Could not register: user must be at least %d years old (age: %d).', $minimumAge, $age),
+            RegistrationFailureReason::UserTooYoung,
+        );
+    }
+
+    public static function becauseDateOfBirthIsInTheFuture(): self
+    {
+        return new self(
+            'Could not register: date of birth cannot be in the future.',
+            RegistrationFailureReason::DateOfBirthInTheFuture,
+        );
     }
 }

--- a/src/Domain/User/Exception/RegistrationFailureReason.php
+++ b/src/Domain/User/Exception/RegistrationFailureReason.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exception;
+
+enum RegistrationFailureReason
+{
+    case EmailAlreadyInUse;
+    case UserTooYoung;
+    case DateOfBirthInTheFuture;
+}

--- a/src/Domain/User/ValueObject/DateOfBirth.php
+++ b/src/Domain/User/ValueObject/DateOfBirth.php
@@ -21,8 +21,26 @@ final readonly class DateOfBirth
         return new self(mb_trim($value));
     }
 
-    public static function fromDateTime(\DateTimeImmutable $dateTime): self
+    public function asString(): string
     {
-        return new self($dateTime->format('Y-m-d'));
+        return $this->value;
+    }
+
+    public function asDateTime(): \DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $this->value, new \DateTimeZone('UTC'));
+        assert($date instanceof \DateTimeImmutable);
+
+        return $date;
+    }
+
+    public function calculateAgeAt(\DateTimeImmutable $referenceDate): int
+    {
+        return $this->asDateTime()->diff($referenceDate)->y;
+    }
+
+    public function isAfter(\DateTimeImmutable $referenceDate): bool
+    {
+        return $this->asDateTime() > $referenceDate;
     }
 }

--- a/src/Domain/User/ValueObject/DisplayName.php
+++ b/src/Domain/User/ValueObject/DisplayName.php
@@ -19,4 +19,9 @@ final readonly class DisplayName
     {
         return new self(mb_trim($value));
     }
+
+    public function asString(): string
+    {
+        return $this->value;
+    }
 }

--- a/src/Infrastructure/Api/Resource/UserRegistrationResource.php
+++ b/src/Infrastructure/Api/Resource/UserRegistrationResource.php
@@ -38,6 +38,12 @@ final readonly class UserRegistrationResource
         #[Assert\Email]
         public string $email,
         #[Assert\NotBlank]
+        #[Assert\Date]
+        public string $dateOfBirth,
+        #[Assert\NotBlank(normalizer: 'trim')]
+        #[Assert\Length(max: 50, maxMessage: 'Display name cannot exceed {{ limit }} characters')]
+        public string $displayName,
+        #[Assert\NotBlank]
         #[Assert\Length(min: 8, minMessage: 'Password must be at least {{ limit }} characters long')]
         public string $password,
     ) {

--- a/src/Infrastructure/DependencyInjection/ClockTimezoneValidatorPass.php
+++ b/src/Infrastructure/DependencyInjection/ClockTimezoneValidatorPass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\DependencyInjection;
 
 use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -25,9 +26,13 @@ final class ClockTimezoneValidatorPass implements CompilerPassInterface
 
         $aliasId = (string) $container->getAlias(ClockInterface::class);
         $definition = $container->findDefinition($aliasId);
+        $class = $definition->getClass();
         $arguments = $definition->getArguments();
 
-        $timezone = $arguments[0] ?? null;
+        // MockClock takes timezone as second argument, NativeClock as first
+        $timezone = $class === MockClock::class
+            ? ($arguments[1] ?? null)
+            : ($arguments[0] ?? null);
 
         if ($timezone !== 'UTC') {
             $timezoneDisplay = is_string($timezone)

--- a/src/Infrastructure/Projection/UserProjection.php
+++ b/src/Infrastructure/Projection/UserProjection.php
@@ -27,6 +27,8 @@ final readonly class UserProjection
             ['_id' => $event->id],
             ['$set' => [
                 'email' => $event->email,
+                'date_of_birth' => $event->dateOfBirth,
+                'display_name' => $event->displayName,
                 'hashed_password' => $event->hashedPassword,
                 'registered_at' => new UTCDateTime($event->occurredAt),
             ]],

--- a/tests/Integration/Infrastructure/DependencyInjection/ClockTimezoneValidatorPassTest.php
+++ b/tests/Integration/Infrastructure/DependencyInjection/ClockTimezoneValidatorPassTest.php
@@ -9,6 +9,7 @@ use App\Infrastructure\Kernel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -79,6 +80,45 @@ final class ClockTimezoneValidatorPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testItPassesWhenMockClockIsConfiguredWithUtc(): void
+    {
+        $container = self::createContainerWithMockClock('2025-01-01 00:00:00', 'UTC');
+
+        $pass = new ClockTimezoneValidatorPass();
+        $pass->process($container);
+
+        // If we get here without exception, the test passes
+        $this->addToAssertionCount(1);
+    }
+
+    public function testItThrowsWhenMockClockIsConfiguredWithNonUtcTimezone(): void
+    {
+        $container = self::createContainerWithMockClock('2025-01-01 00:00:00', 'America/New_York');
+
+        $pass = new ClockTimezoneValidatorPass();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Clock must be configured with UTC timezone, got "America/New_York"');
+
+        $pass->process($container);
+    }
+
+    public function testItThrowsWhenMockClockHasNoTimezoneArgument(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(MockClock::class, MockClock::class)
+            ->addArgument('2025-01-01 00:00:00')
+        ;
+        $container->setAlias(ClockInterface::class, MockClock::class);
+
+        $pass = new ClockTimezoneValidatorPass();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Clock must be configured with UTC timezone, got null');
+
+        $pass->process($container);
+    }
+
     public function testKernelFailsToBootWithNonUtcClock(): void
     {
         $kernel = new Kernel('invalid_clock_test', false);
@@ -96,6 +136,18 @@ final class ClockTimezoneValidatorPassTest extends TestCase
             ->addArgument($timezone)
         ;
         $container->setAlias(ClockInterface::class, NativeClock::class);
+
+        return $container;
+    }
+
+    private static function createContainerWithMockClock(string $datetime, ?string $timezone): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->register(MockClock::class, MockClock::class)
+            ->addArgument($datetime)
+            ->addArgument($timezone)
+        ;
+        $container->setAlias(ClockInterface::class, MockClock::class);
 
         return $container;
     }

--- a/tests/Integration/Infrastructure/EventDispatchIntegrationTest.php
+++ b/tests/Integration/Infrastructure/EventDispatchIntegrationTest.php
@@ -71,6 +71,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event = new UserRegistered(
             id: $userId,
             email: $email,
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: $occurredAt,
         );
@@ -103,6 +105,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event1 = new UserRegistered(
             id: $userId1,
             email: $email1,
+            dateOfBirth: '1990-05-15',
+            displayName: 'First User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         );
@@ -112,6 +116,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event2 = new UserRegistered(
             id: $userId2,
             email: $email2,
+            dateOfBirth: '1990-05-15',
+            displayName: 'Second User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         );
@@ -133,6 +139,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event1 = new UserRegistered(
             id: $userId,
             email: $initialEmail,
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: $occurredAt,
         );
@@ -143,6 +151,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event2 = new UserRegistered(
             id: $userId,
             email: $initialEmail,
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: $occurredAt->modify('+1 second'),
         );
@@ -167,6 +177,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event = new UserRegistered(
             id: $userId,
             email: $email,
+            dateOfBirth: '1990-05-15',
+            displayName: 'Integrity User',
             hashedPassword: 'hashed_password',
             occurredAt: $registeredAt,
         );
@@ -194,6 +206,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event1 = new UserRegistered(
             id: $userId,
             email: $email,
+            dateOfBirth: '1990-05-15',
+            displayName: 'Concurrency User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         );
@@ -206,6 +220,8 @@ final class EventDispatchIntegrationTest extends KernelTestCase
         $event2 = new UserRegistered(
             id: $userId,
             email: 'updated@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Concurrency User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         );

--- a/tests/Integration/Infrastructure/Persistence/EventStoreContractTest.php
+++ b/tests/Integration/Infrastructure/Persistence/EventStoreContractTest.php
@@ -193,6 +193,8 @@ final class EventStoreContractTest extends TestCase
         $event = new UserRegistered(
             id: $aggregateId,
             email: 'datetime@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: $specificTime,
         );
@@ -288,6 +290,8 @@ final class EventStoreContractTest extends TestCase
         return new UserRegistered(
             id: $aggregateId,
             email: $email,
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable('2025-01-01 12:00:00'),
         );

--- a/tests/Integration/Infrastructure/Persistence/MongoEventStoreTest.php
+++ b/tests/Integration/Infrastructure/Persistence/MongoEventStoreTest.php
@@ -52,6 +52,8 @@ final class MongoEventStoreTest extends TestCase
         $event = new UserRegistered(
             id: $aggregateId,
             email: 'document@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: $specificTime,
         );

--- a/tests/Integration/Infrastructure/Persistence/UserReadModelContractTest.php
+++ b/tests/Integration/Infrastructure/Persistence/UserReadModelContractTest.php
@@ -171,6 +171,8 @@ final class UserReadModelContractTest extends TestCase
             $readModel->handleEvent(new UserRegistered(
                 id: 'user-' . md5($email),
                 email: $email,
+                dateOfBirth: '1990-05-15',
+                displayName: 'Test User',
                 hashedPassword: 'hashed_password',
                 occurredAt: new \DateTimeImmutable(),
             ));
@@ -193,6 +195,8 @@ final class UserReadModelContractTest extends TestCase
             $projection->onUserRegistered(new UserRegistered(
                 id: 'user-' . md5($email),
                 email: $email,
+                dateOfBirth: '1990-05-15',
+                displayName: 'Test User',
                 hashedPassword: 'hashed_password',
                 occurredAt: new \DateTimeImmutable(),
             ));

--- a/tests/Integration/Infrastructure/Projection/UserProjectionTest.php
+++ b/tests/Integration/Infrastructure/Projection/UserProjectionTest.php
@@ -42,6 +42,8 @@ final class UserProjectionTest extends TestCase
         $event = new UserRegistered(
             id: 'user-123',
             email: 'john@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'John Doe',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable('2025-01-15T10:30:00+00:00'),
         );
@@ -60,6 +62,8 @@ final class UserProjectionTest extends TestCase
         $event = new UserRegistered(
             id: 'user-456',
             email: 'John.Doe@Example.COM', // Mixed case to verify no normalization
+            dateOfBirth: '1990-05-15',
+            displayName: 'John Doe',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         );
@@ -76,6 +80,8 @@ final class UserProjectionTest extends TestCase
         $event = new UserRegistered(
             id: 'user-idempotent',
             email: 'idempotent@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         );
@@ -94,6 +100,8 @@ final class UserProjectionTest extends TestCase
         $this->projection->onUserRegistered(new UserRegistered(
             id: 'user-1',
             email: 'first@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'First User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         ));
@@ -101,6 +109,8 @@ final class UserProjectionTest extends TestCase
         $this->projection->onUserRegistered(new UserRegistered(
             id: 'user-2',
             email: 'second@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Second User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         ));
@@ -108,6 +118,8 @@ final class UserProjectionTest extends TestCase
         $this->projection->onUserRegistered(new UserRegistered(
             id: 'user-3',
             email: 'third@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Third User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         ));
@@ -126,6 +138,8 @@ final class UserProjectionTest extends TestCase
         $event = new UserRegistered(
             id: 'user-timestamp',
             email: 'timestamp@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: 'hashed_password',
             occurredAt: $registeredAt,
         );
@@ -145,6 +159,8 @@ final class UserProjectionTest extends TestCase
         $event = new UserRegistered(
             id: 'user-password-test',
             email: 'password-test@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Test User',
             hashedPassword: '$2y$10$abcdefghijklmnopqrstuv',
             occurredAt: new \DateTimeImmutable(),
         );
@@ -162,6 +178,8 @@ final class UserProjectionTest extends TestCase
         $registeredEvent = new UserRegistered(
             id: 'user-login-test',
             email: 'login@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Login User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable('2025-01-15T10:00:00+00:00'),
         );
@@ -190,6 +208,8 @@ final class UserProjectionTest extends TestCase
         $this->projection->onUserRegistered(new UserRegistered(
             id: 'user-multi-login',
             email: 'multi-login@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Multi Login User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable('2025-01-01T00:00:00+00:00'),
         ));
@@ -225,6 +245,8 @@ final class UserProjectionTest extends TestCase
         $this->projection->onUserRegistered(new UserRegistered(
             id: 'user-idempotent-login',
             email: 'idempotent-login@example.com',
+            dateOfBirth: '1990-05-15',
+            displayName: 'Idempotent User',
             hashedPassword: 'hashed_password',
             occurredAt: new \DateTimeImmutable(),
         ));

--- a/tests/Unit/Domain/User/UserTest.php
+++ b/tests/Unit/Domain/User/UserTest.php
@@ -8,7 +8,10 @@ use App\Domain\Common\Event\DomainEventInterface;
 use App\Domain\User\Event\UserLoggedIn;
 use App\Domain\User\Event\UserRegistered;
 use App\Domain\User\Exception\CouldNotAuthenticate;
+use App\Domain\User\Exception\CouldNotRegister;
 use App\Domain\User\User;
+use App\Domain\User\ValueObject\DateOfBirth;
+use App\Domain\User\ValueObject\DisplayName;
 use App\Domain\User\ValueObject\Email;
 use App\Domain\User\ValueObject\HashedPassword;
 use App\Domain\User\ValueObject\PlainPassword;
@@ -23,18 +26,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(User::class)]
 #[UsesClass(UserId::class)]
 #[UsesClass(Email::class)]
+#[UsesClass(DateOfBirth::class)]
+#[UsesClass(DisplayName::class)]
 #[UsesClass(HashedPassword::class)]
 #[UsesClass(PlainPassword::class)]
 final class UserTest extends TestCase
 {
-    public function testItRecordsUserRegisteredEvent(): void
-    {
-        $userId = UserId::fromString('550e8400-e29b-41d4-a716-446655440000');
-        $email = Email::fromString('test@example.com');
-        $password = HashedPassword::fromHash('$2y$10$hashedpassword');
-        $registeredAt = new \DateTimeImmutable('2025-11-27 20:00:00', new \DateTimeZone('UTC'));
+    private const string DEFAULT_USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+    private const string DEFAULT_EMAIL = 'test@example.com';
+    private const string DEFAULT_DATE_OF_BIRTH = '1990-05-15';
+    private const string DEFAULT_DISPLAY_NAME = 'Test User';
+    private const string DEFAULT_PASSWORD_HASH = '$2y$10$hashedpassword';
+    private const string VERIFIABLE_PLAIN_PASSWORD = 'SecurePass123!';
+    private const int TEST_BCRYPT_COST = 4;
 
-        $user = User::register($userId, $email, $password, $registeredAt);
+    public function testRegisterRecordsUserRegisteredEvent(): void
+    {
+        $registeredAt = self::createRegisteredAt();
+        $user = self::registerUser(registeredAt: $registeredAt);
 
         $events = $user->releaseEvents();
 
@@ -42,24 +51,43 @@ final class UserTest extends TestCase
 
         $event = $events[0];
         self::assertInstanceOf(UserRegistered::class, $event);
-        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $event->id);
-        self::assertSame('test@example.com', $event->email);
-        self::assertSame('$2y$10$hashedpassword', $event->hashedPassword);
+        self::assertSame(self::DEFAULT_USER_ID, $event->id);
+        self::assertSame(self::DEFAULT_EMAIL, $event->email);
+        self::assertSame(self::DEFAULT_DATE_OF_BIRTH, $event->dateOfBirth);
+        self::assertSame(self::DEFAULT_DISPLAY_NAME, $event->displayName);
+        self::assertSame(self::DEFAULT_PASSWORD_HASH, $event->hashedPassword);
         self::assertSame($registeredAt, $event->occurredAt);
+    }
+
+    public function testRegisterThrowsExceptionWhenUserIsUnder18(): void
+    {
+        $this->expectException(CouldNotRegister::class);
+        $this->expectExceptionMessage('user must be at least 18 years old (age: 15)');
+
+        self::registerUser(dateOfBirth: '2010-06-15'); // 15 years old on 2025-12-12
+    }
+
+    public function testRegisterSucceedsWhenUserIsExactly18(): void
+    {
+        $user = self::registerUser(dateOfBirth: '2007-12-12'); // Exactly 18 on 2025-12-12
+
+        $events = $user->releaseEvents();
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(UserRegistered::class, $events[0]);
+    }
+
+    public function testRegisterThrowsExceptionWhenDateOfBirthIsInTheFuture(): void
+    {
+        $this->expectException(CouldNotRegister::class);
+        $this->expectExceptionMessage('date of birth cannot be in the future');
+
+        self::registerUser(dateOfBirth: '2030-01-01'); // Future date
     }
 
     public function testItReconstitutesUserFromEventsWithoutRecordingNewEvents(): void
     {
-        $events = [
-            new UserRegistered(
-                '550e8400-e29b-41d4-a716-446655440000',
-                'test@example.com',
-                '$2y$10$hashedpassword',
-                new \DateTimeImmutable('2025-11-27 20:00:00', new \DateTimeZone('UTC')),
-            ),
-        ];
-
-        $user = User::reconstitute($events);
+        $user = User::reconstitute([self::createUserRegisteredEvent()]);
 
         // reconstitute() should apply events but NOT record new ones
         self::assertEmpty($user->releaseEvents());
@@ -83,91 +111,92 @@ final class UserTest extends TestCase
 
     public function testLoginRecordsUserLoggedInEvent(): void
     {
-        // Arrange: Create a user with known password
-        $userId = UserId::fromString('550e8400-e29b-41d4-a716-446655440000');
-        $email = Email::fromString('test@example.com');
-        $plainPassword = PlainPassword::fromString('SecurePass123!');
-        $hashedPassword = HashedPassword::fromHash(password_hash('SecurePass123!', PASSWORD_BCRYPT, ['cost' => 4]));
-        $registeredAt = new \DateTimeImmutable('2025-11-27 20:00:00', new \DateTimeZone('UTC'));
+        $user = User::reconstitute([
+            self::createUserRegisteredEvent(passwordHash: self::createVerifiablePasswordHash()),
+        ]);
 
-        $user = User::register($userId, $email, $hashedPassword, $registeredAt);
-        $user->releaseEvents(); // Clear registration event
+        $loginTimestamp = self::createLoginTimestamp();
+        $user->login(PlainPassword::fromString(self::VERIFIABLE_PLAIN_PASSWORD), $loginTimestamp);
 
-        // Act: Login with correct password
-        $loginTimestamp = new \DateTimeImmutable('2025-11-28 10:00:00', new \DateTimeZone('UTC'));
-        $user->login($plainPassword, $loginTimestamp);
-
-        // Assert: UserLoggedIn event was recorded
         $events = $user->releaseEvents();
         self::assertCount(1, $events);
 
         $event = $events[0];
         self::assertInstanceOf(UserLoggedIn::class, $event);
-        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $event->id);
+        self::assertSame(self::DEFAULT_USER_ID, $event->id);
         self::assertSame($loginTimestamp, $event->occurredAt);
     }
 
     public function testLoginThrowsExceptionForInvalidPassword(): void
     {
-        // Arrange: Create a user with known password
-        $userId = UserId::fromString('550e8400-e29b-41d4-a716-446655440000');
-        $email = Email::fromString('test@example.com');
-        $hashedPassword = HashedPassword::fromHash(password_hash('SecurePass123!', PASSWORD_BCRYPT, ['cost' => 4]));
-        $registeredAt = new \DateTimeImmutable('2025-11-27 20:00:00', new \DateTimeZone('UTC'));
-
-        $user = User::register($userId, $email, $hashedPassword, $registeredAt);
-        $user->releaseEvents(); // Clear registration event
-
-        // Act & Assert: Login with wrong password throws exception
-        $wrongPassword = PlainPassword::fromString('WrongPassword123!');
-        $loginTimestamp = new \DateTimeImmutable('2025-11-28 10:00:00', new \DateTimeZone('UTC'));
+        $user = User::reconstitute([
+            self::createUserRegisteredEvent(passwordHash: self::createVerifiablePasswordHash()),
+        ]);
 
         $this->expectException(CouldNotAuthenticate::class);
 
-        $user->login($wrongPassword, $loginTimestamp);
+        $user->login(PlainPassword::fromString('WrongPassword123!'), self::createLoginTimestamp());
     }
 
-    public function testReconstitutesUserWithLoginEvent(): void
+    public function testItCanReconstituteUserWithLoginEvent(): void
     {
-        // Arrange: Create event stream with registration + login
-        $userId = '550e8400-e29b-41d4-a716-446655440000';
-        $email = 'test@example.com';
-        $passwordHash = '$2y$10$hashedpassword';
-        $registeredAt = new \DateTimeImmutable('2025-11-27 20:00:00', new \DateTimeZone('UTC'));
-        $loginTimestamp = new \DateTimeImmutable('2025-11-28 10:00:00', new \DateTimeZone('UTC'));
+        $user = User::reconstitute([
+            self::createUserRegisteredEvent(),
+            new UserLoggedIn(self::DEFAULT_USER_ID, self::createLoginTimestamp()),
+        ]);
 
-        $events = [
-            new UserRegistered($userId, $email, $passwordHash, $registeredAt),
-            new UserLoggedIn($userId, $loginTimestamp),
-        ];
-
-        // Act: Reconstitute user
-        $user = User::reconstitute($events);
-
-        // Assert: No errors and no new events recorded
+        // No errors and no new events recorded
         self::assertEmpty($user->releaseEvents());
     }
 
-    public function testReconstitutedUserCanLogin(): void
+    private static function createRegisteredAt(): \DateTimeImmutable
     {
-        // Arrange: Create event with real bcrypt hash and reconstitute
-        $userId = '550e8400-e29b-41d4-a716-446655440000';
-        $passwordHash = password_hash('SecurePass123!', PASSWORD_BCRYPT, ['cost' => 4]);
-        $registeredAt = new \DateTimeImmutable('2025-11-27 20:00:00', new \DateTimeZone('UTC'));
+        return new \DateTimeImmutable('2025-12-12 12:00:00', new \DateTimeZone('UTC'));
+    }
 
-        $events = [
-            new UserRegistered($userId, 'test@example.com', $passwordHash, $registeredAt),
-        ];
+    private static function createLoginTimestamp(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('2025-12-13 10:00:00', new \DateTimeZone('UTC'));
+    }
 
-        $user = User::reconstitute($events);
+    private static function createVerifiablePasswordHash(): string
+    {
+        return password_hash(self::VERIFIABLE_PLAIN_PASSWORD, PASSWORD_BCRYPT, ['cost' => self::TEST_BCRYPT_COST]);
+    }
 
-        // Act: Login with correct password
-        $loginTimestamp = new \DateTimeImmutable('2025-11-28 10:00:00', new \DateTimeZone('UTC'));
-        $user->login(PlainPassword::fromString('SecurePass123!'), $loginTimestamp);
+    private static function registerUser(
+        ?string $userId = null,
+        ?string $email = null,
+        ?string $dateOfBirth = null,
+        ?string $displayName = null,
+        ?string $passwordHash = null,
+        ?\DateTimeImmutable $registeredAt = null,
+    ): User {
+        return User::register(
+            UserId::fromString($userId ?? self::DEFAULT_USER_ID),
+            Email::fromString($email ?? self::DEFAULT_EMAIL),
+            DateOfBirth::fromString($dateOfBirth ?? self::DEFAULT_DATE_OF_BIRTH),
+            DisplayName::fromString($displayName ?? self::DEFAULT_DISPLAY_NAME),
+            HashedPassword::fromHash($passwordHash ?? self::DEFAULT_PASSWORD_HASH),
+            $registeredAt ?? self::createRegisteredAt(),
+        );
+    }
 
-        // Assert: UserLoggedIn event was recorded
-        $events = $user->releaseEvents();
-        self::assertCount(1, $events);
-        self::assertInstanceOf(UserLoggedIn::class, $events[0]);
+    private static function createUserRegisteredEvent(
+        ?string $userId = null,
+        ?string $email = null,
+        ?string $dateOfBirth = null,
+        ?string $displayName = null,
+        ?string $passwordHash = null,
+        ?\DateTimeImmutable $occurredAt = null,
+    ): UserRegistered {
+        return new UserRegistered(
+            $userId ?? self::DEFAULT_USER_ID,
+            $email ?? self::DEFAULT_EMAIL,
+            $dateOfBirth ?? self::DEFAULT_DATE_OF_BIRTH,
+            $displayName ?? self::DEFAULT_DISPLAY_NAME,
+            $passwordHash ?? self::DEFAULT_PASSWORD_HASH,
+            $occurredAt ?? self::createRegisteredAt(),
+        );
     }
 }

--- a/tests/Unit/Domain/User/ValueObject/DisplayNameTest.php
+++ b/tests/Unit/Domain/User/ValueObject/DisplayNameTest.php
@@ -75,4 +75,18 @@ final class DisplayNameTest extends TestCase
 
         yield '50 characters in another alphabet' => [str_repeat('あ', 50)];
     }
+
+    public function testItReturnsStringRepresentation(): void
+    {
+        $displayName = DisplayName::fromString('John Doe');
+
+        self::assertSame('John Doe', $displayName->asString());
+    }
+
+    public function testItTrimsWhitespaceFromInput(): void
+    {
+        $displayName = DisplayName::fromString('  John Doe  ');
+
+        self::assertSame('John Doe', $displayName->asString());
+    }
 }

--- a/tests/Unit/Infrastructure/Persistence/EventStore/DispatchingEventStoreTest.php
+++ b/tests/Unit/Infrastructure/Persistence/EventStore/DispatchingEventStoreTest.php
@@ -24,7 +24,7 @@ final class DispatchingEventStoreTest extends TestCase
     {
         $aggregateId = 'user-123';
         $aggregateType = 'App\Domain\User\User';
-        $event = new UserRegistered('user-123', 'test@example.com', 'hashed_password', new \DateTimeImmutable());
+        $event = new UserRegistered('user-123', 'test@example.com', '1990-05-15', 'Test User', 'hashed_password', new \DateTimeImmutable());
         $events = [$event];
         $expectedVersion = 0;
 
@@ -49,8 +49,8 @@ final class DispatchingEventStoreTest extends TestCase
         $aggregateId = 'user-123';
         $aggregateType = 'App\Domain\User\User';
         // Using same aggregate ID for both events (realistic for multi-event append)
-        $event1 = new UserRegistered('user-123', 'test@example.com', 'hashed_password', new \DateTimeImmutable());
-        $event2 = new UserRegistered('user-123', 'test@example.com', 'hashed_password', new \DateTimeImmutable());
+        $event1 = new UserRegistered('user-123', 'test@example.com', '1990-05-15', 'Test User', 'hashed_password', new \DateTimeImmutable());
+        $event2 = new UserRegistered('user-123', 'test@example.com', '1990-05-15', 'Test User', 'hashed_password', new \DateTimeImmutable());
         $events = [$event1, $event2];
         $expectedVersion = 0;
 
@@ -79,7 +79,7 @@ final class DispatchingEventStoreTest extends TestCase
     {
         $aggregateId = 'user-123';
         $aggregateType = 'App\Domain\User\User';
-        $event = new UserRegistered('user-123', 'test@example.com', 'hashed_password', new \DateTimeImmutable());
+        $event = new UserRegistered('user-123', 'test@example.com', '1990-05-15', 'Test User', 'hashed_password', new \DateTimeImmutable());
         $events = [$event];
         $expectedVersion = 1;
 
@@ -113,7 +113,7 @@ final class DispatchingEventStoreTest extends TestCase
     {
         $aggregateId = 'user-123';
         $aggregateType = 'App\Domain\User\User';
-        $event = new UserRegistered('user-123', 'test@example.com', 'hashed_password', new \DateTimeImmutable());
+        $event = new UserRegistered('user-123', 'test@example.com', '1990-05-15', 'Test User', 'hashed_password', new \DateTimeImmutable());
         $events = [$event];
         $expectedVersion = 0;
 
@@ -143,8 +143,8 @@ final class DispatchingEventStoreTest extends TestCase
     {
         $aggregateId = 'user-123';
         $aggregateType = 'App\Domain\User\User';
-        $event1 = new UserRegistered('user-123', 'test@example.com', 'hashed_password', new \DateTimeImmutable());
-        $event2 = new UserRegistered('user-123', 'updated@example.com', 'hashed_password', new \DateTimeImmutable());
+        $event1 = new UserRegistered('user-123', 'test@example.com', '1990-05-15', 'Test User', 'hashed_password', new \DateTimeImmutable());
+        $event2 = new UserRegistered('user-123', 'updated@example.com', '1990-05-15', 'Test User', 'hashed_password', new \DateTimeImmutable());
         $expectedEvents = [$event1, $event2];
 
         $inner = $this->createMock(EventStoreInterface::class);

--- a/tests/UseCase/TestContainer.php
+++ b/tests/UseCase/TestContainer.php
@@ -21,10 +21,11 @@ final class TestContainer
     public readonly InMemoryEventStore $eventStore;
     public readonly InMemoryCommandBus $commandBus;
     public readonly InMemoryQueryBus $queryBus;
+    public readonly MockClock $clock;
 
     public function __construct()
     {
-        $clock = new MockClock('2025-12-12 12:00:00 UTC');
+        $this->clock = new MockClock('2025-12-12 12:00:00 UTC');
         $passwordHasher = new FakePasswordHasher();
         $userReadModel = new InMemoryUserReadModel();
 
@@ -37,7 +38,7 @@ final class TestContainer
             new RegisterUserHandler(
                 $this->eventStore,
                 $userReadModel,
-                $clock,
+                $this->clock,
                 $passwordHasher,
             ),
         );
@@ -45,7 +46,7 @@ final class TestContainer
             LoginCommand::class,
             new LoginHandler(
                 $this->eventStore,
-                $clock,
+                $this->clock,
             ),
         );
 


### PR DESCRIPTION
## Summary

- Add `dateOfBirth` and `displayName` fields to user registration
- Implement 18+ age validation with future date rejection
- Add display name validation (non-empty, max 50 chars, trimmed)
- Update domain, application, and infrastructure layers

## Test plan

- [x] Unit tests for DateOfBirth and DisplayName value objects
- [x] Unit tests for User aggregate age validation
- [x] Use case tests via Behat scenarios
- [x] Integration tests for API endpoint
- [x] E2E tests with real infrastructure
- [x] 100% code coverage maintained

Closes #10