### PR TITLE
feat: Add /me endpoint for user profile

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,26 +4,22 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
-        users_in_memory: { memory: null }
+        jwt_user_provider:
+            id: App\Infrastructure\Security\JwtUserProvider
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
-
-            # activate different ways to authenticate
-            # https://symfony.com/doc/current/security.html#the-firewall
-
-            # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
+            stateless: true
+            provider: jwt_user_provider
+            jwt: ~
 
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/api/me$, roles: IS_AUTHENTICATED_FULLY }
 
 when@test:
     security:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,6 +33,10 @@ services:
         tags:
             - { name: messenger.message_handler, bus: query.bus }
 
+    App\Application\User\Query\GetUserInfoHandler:
+        tags:
+            - { name: messenger.message_handler, bus: query.bus }
+
     # MongoDB Client
     MongoDB\Client:
         arguments:
@@ -79,6 +83,13 @@ services:
 
     App\Application\User\Query\FindUserAuthData:
         alias: App\Infrastructure\Persistence\MongoDB\MongoFindUserAuthData
+
+    App\Infrastructure\Persistence\MongoDB\MongoGetUserInfo:
+        arguments:
+            $collection: '@mongodb.collection.users'
+
+    App\Application\User\Query\GetUserInfo:
+        alias: App\Infrastructure\Persistence\MongoDB\MongoGetUserInfo
 
     # Projections
     App\Infrastructure\Projection\UserProjection:

--- a/features/user/current-user.feature
+++ b/features/user/current-user.feature
@@ -30,5 +30,13 @@ Feature: Current User Info
 
   @e2e
   Scenario: Cannot access user info without authentication
-    When I request my user info without authentication
+    Given I am not authenticated
+    When I request my user info
     Then I should receive a 401 Unauthorized error
+
+  @e2e
+  Scenario: Cannot access user info after account deletion
+    Given I am logged in as "alice@example.com" with password "SecurePass123!"
+    And my account was deleted
+    When I request my user info
+    Then I should receive a 404 Not Found error

--- a/features/user/current-user.feature
+++ b/features/user/current-user.feature
@@ -1,0 +1,34 @@
+Feature: Current User Info
+  In order to personalize my experience
+  As an authenticated user
+  I need to be able to retrieve my account information
+
+  Background:
+    Given today's date is "December 15, 2025"
+    And a user registered with:
+      | email       | alice@example.com |
+      | displayName | Alice Wonderland  |
+      | dateOfBirth | 1990-05-15        |
+      | password    | SecurePass123!    |
+
+  Scenario: Successfully fetch current user info
+    Given I am logged in as "alice@example.com" with password "SecurePass123!"
+    When I request my user info
+    Then I should receive my user info with:
+      | email       | alice@example.com |
+      | displayName | Alice Wonderland  |
+
+  Scenario: User info includes registration timestamp in ISO 8601 format
+    Given I am logged in as "alice@example.com" with password "SecurePass123!"
+    When I request my user info
+    Then my user info should include a valid registration timestamp
+
+  Scenario: User info includes user ID
+    Given I am logged in as "alice@example.com" with password "SecurePass123!"
+    When I request my user info
+    Then my user info should include my user ID
+
+  @e2e
+  Scenario: Cannot access user info without authentication
+    When I request my user info without authentication
+    Then I should receive a 401 Unauthorized error

--- a/src/Application/User/Query/GetUserInfo.php
+++ b/src/Application/User/Query/GetUserInfo.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+use App\Domain\User\Exception\CouldNotFindUser;
+use App\Domain\User\ValueObject\UserId;
+
+/**
+ * Retrieves user information for display.
+ *
+ * Returns a UserInfo view model containing the user's
+ * public profile information.
+ */
+interface GetUserInfo
+{
+    /**
+     * @throws CouldNotFindUser When the user does not exist
+     */
+    public function byId(UserId $userId): UserInfo;
+}

--- a/src/Application/User/Query/GetUserInfoHandler.php
+++ b/src/Application/User/Query/GetUserInfoHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+use App\Domain\User\ValueObject\UserId;
+
+/**
+ * Handler for GetUserInfoQuery.
+ */
+final readonly class GetUserInfoHandler
+{
+    public function __construct(
+        private GetUserInfo $getUserInfo,
+    ) {
+    }
+
+    public function __invoke(GetUserInfoQuery $query): UserInfo
+    {
+        return $this->getUserInfo->byId(
+            UserId::fromString($query->userId),
+        );
+    }
+}

--- a/src/Application/User/Query/GetUserInfoQuery.php
+++ b/src/Application/User/Query/GetUserInfoQuery.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+use App\Application\MessageBus\QueryInterface;
+
+/**
+ * Query to get user information by ID.
+ *
+ * @implements QueryInterface<UserInfo>
+ */
+final readonly class GetUserInfoQuery implements QueryInterface
+{
+    /**
+     * @param non-empty-string $userId
+     */
+    public function __construct(
+        public string $userId,
+    ) {
+    }
+}

--- a/src/Application/User/Query/UserInfo.php
+++ b/src/Application/User/Query/UserInfo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+/**
+ * Data transfer object for user information.
+ */
+final readonly class UserInfo
+{
+    /**
+     * @param non-empty-string $id
+     * @param non-empty-string $email
+     * @param non-empty-string $displayName
+     * @param non-empty-string $registeredAt ISO 8601 format
+     */
+    public function __construct(
+        public string $id,
+        public string $email,
+        public string $displayName,
+        public string $registeredAt,
+    ) {
+    }
+}

--- a/src/Domain/User/Exception/CouldNotFindUser.php
+++ b/src/Domain/User/Exception/CouldNotFindUser.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exception;
+
+use App\Domain\User\ValueObject\UserId;
+
+/**
+ * Exception when a user cannot be found.
+ */
+final class CouldNotFindUser extends \DomainException
+{
+    public static function withId(UserId $userId): self
+    {
+        return new self(sprintf('Could not find user with ID "%s".', $userId->asString()));
+    }
+}

--- a/src/Infrastructure/Api/Resource/CurrentUserResource.php
+++ b/src/Infrastructure/Api/Resource/CurrentUserResource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Api\Resource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\Infrastructure\Api\State\GetCurrentUserInfoProvider;
+
+/**
+ * API resource for the current user's info.
+ *
+ * Returns the authenticated user's profile information.
+ */
+#[ApiResource(
+    shortName: 'CurrentUser',
+    operations: [
+        new Get(
+            uriTemplate: '/me',
+            provider: GetCurrentUserInfoProvider::class,
+            openapi: new Operation(
+                summary: 'Get current user info',
+                description: 'Returns the authenticated user\'s profile information.',
+                security: [['bearerAuth' => []]],
+            ),
+        ),
+    ],
+)]
+final readonly class CurrentUserResource
+{
+    /**
+     * @param non-empty-string $id
+     * @param non-empty-string $email
+     * @param non-empty-string $displayName
+     * @param non-empty-string $registeredAt ISO 8601 format
+     */
+    public function __construct(
+        public string $id,
+        public string $email,
+        public string $displayName,
+        public string $registeredAt,
+    ) {
+    }
+}

--- a/src/Infrastructure/Api/State/GetCurrentUserInfoProvider.php
+++ b/src/Infrastructure/Api/State/GetCurrentUserInfoProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Api\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Application\MessageBus\QueryBusInterface;
+use App\Application\User\Query\GetUserInfoQuery;
+use App\Infrastructure\Api\Resource\CurrentUserResource;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * State provider for the current user's info.
+ *
+ * Fetches the authenticated user's profile information.
+ * This is a "driving adapter" in hexagonal architecture.
+ *
+ * @implements ProviderInterface<CurrentUserResource>
+ */
+final readonly class GetCurrentUserInfoProvider implements ProviderInterface
+{
+    public function __construct(
+        private Security $security,
+        private QueryBusInterface $queryBus,
+    ) {
+    }
+
+    #[\Override]
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): CurrentUserResource
+    {
+        $user = $this->security->getUser();
+        assert($user !== null, 'User must be authenticated to access this endpoint');
+
+        $userId = $user->getUserIdentifier();
+
+        $userInfo = $this->queryBus->dispatch(
+            new GetUserInfoQuery($userId),
+        );
+
+        return new CurrentUserResource(
+            id: $userInfo->id,
+            email: $userInfo->email,
+            displayName: $userInfo->displayName,
+            registeredAt: $userInfo->registeredAt,
+        );
+    }
+}

--- a/src/Infrastructure/Api/State/GetCurrentUserInfoProvider.php
+++ b/src/Infrastructure/Api/State/GetCurrentUserInfoProvider.php
@@ -8,8 +8,10 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Application\MessageBus\QueryBusInterface;
 use App\Application\User\Query\GetUserInfoQuery;
+use App\Domain\User\Exception\CouldNotFindUser;
 use App\Infrastructure\Api\Resource\CurrentUserResource;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * State provider for the current user's info.
@@ -35,9 +37,13 @@ final readonly class GetCurrentUserInfoProvider implements ProviderInterface
 
         $userId = $user->getUserIdentifier();
 
-        $userInfo = $this->queryBus->dispatch(
-            new GetUserInfoQuery($userId),
-        );
+        try {
+            $userInfo = $this->queryBus->dispatch(
+                new GetUserInfoQuery($userId),
+            );
+        } catch (CouldNotFindUser $e) {
+            throw new NotFoundHttpException($e->getMessage(), $e);
+        }
 
         return new CurrentUserResource(
             id: $userInfo->id,

--- a/src/Infrastructure/Persistence/MongoDB/MongoGetUserInfo.php
+++ b/src/Infrastructure/Persistence/MongoDB/MongoGetUserInfo.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\MongoDB;
+
+use App\Application\User\Query\GetUserInfo;
+use App\Application\User\Query\UserInfo;
+use App\Domain\User\Exception\CouldNotFindUser;
+use App\Domain\User\ValueObject\UserId;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Collection;
+use MongoDB\Model\BSONDocument;
+
+/**
+ * MongoDB implementation of the GetUserInfo finder.
+ */
+final readonly class MongoGetUserInfo implements GetUserInfo
+{
+    /**
+     * @codeCoverageIgnore Empty constructor
+     */
+    public function __construct(
+        private Collection $collection,
+    ) {
+    }
+
+    #[\Override]
+    public function byId(UserId $userId): UserInfo
+    {
+        $document = $this->collection->findOne(
+            ['_id' => $userId->asString()],
+            ['projection' => [
+                '_id' => 1,
+                'email' => 1,
+                'display_name' => 1,
+                'registered_at' => 1,
+            ]],
+        );
+
+        if ($document === null) {
+            throw CouldNotFindUser::withId($userId);
+        }
+
+        assert($document instanceof BSONDocument);
+
+        $id = $document['_id'];
+        $email = $document['email'];
+        $displayName = $document['display_name'];
+        $registeredAt = $document['registered_at'];
+
+        assert(is_string($id) && $id !== '');
+        assert(is_string($email) && $email !== '');
+        assert(is_string($displayName) && $displayName !== '');
+        assert($registeredAt instanceof UTCDateTime);
+
+        return new UserInfo(
+            id: $id,
+            email: $email,
+            displayName: $displayName,
+            registeredAt: $registeredAt->toDateTime()->format(\DateTimeInterface::ATOM),
+        );
+    }
+}

--- a/src/Infrastructure/Security/JwtUserProvider.php
+++ b/src/Infrastructure/Security/JwtUserProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security;
+
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * User provider for JWT authentication.
+ *
+ * This provider creates SecurityUser instances from the JWT payload.
+ * The user identifier in the JWT is the user ID.
+ *
+ * @implements UserProviderInterface<SecurityUser>
+ */
+final class JwtUserProvider implements UserProviderInterface
+{
+    #[\Override]
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        // The identifier from JWT is the user ID
+        // We create a minimal SecurityUser - the profile endpoint will fetch full data
+        assert($identifier !== '');
+
+        return new SecurityUser($identifier);
+    }
+
+    #[\Override]
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        if (!$user instanceof SecurityUser) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', $user::class));
+        }
+
+        // JWT is stateless - return the same user
+        return $user;
+    }
+
+    #[\Override]
+    public function supportsClass(string $class): bool
+    {
+        return SecurityUser::class === $class;
+    }
+}

--- a/tests/E2E/HttpHelper.php
+++ b/tests/E2E/HttpHelper.php
@@ -33,6 +33,25 @@ trait HttpHelper
         return $this->kernel->handle($request);
     }
 
+    /**
+     * @param array<string, string> $headers
+     */
+    private function makeGetRequest(string $uri, array $headers = []): Response
+    {
+        $server = ['HTTP_ACCEPT' => 'application/json'];
+        foreach ($headers as $name => $value) {
+            $server['HTTP_' . mb_strtoupper(str_replace('-', '_', $name))] = $value;
+        }
+
+        $request = Request::create(
+            uri: $uri,
+            method: 'GET',
+            server: $server,
+        );
+
+        return $this->kernel->handle($request);
+    }
+
     private static function assertResponseStatusCode(?Response $response, int $expected, string $description): void
     {
         Assert::notNull($response, 'No response received');

--- a/tests/E2E/UserContext.php
+++ b/tests/E2E/UserContext.php
@@ -208,14 +208,29 @@ final class UserContext implements Context
         $this->kernel->boot();
     }
 
+    #[Given('I am not authenticated')]
+    public function iAmNotAuthenticated(): void
+    {
+        $this->authToken = null;
+    }
+
+    #[Given('my account was deleted')]
+    public function myAccountWasDeleted(): void
+    {
+        // Delete all user data from MongoDB while keeping the JWT token
+        $this->database->selectCollection('event_store')->deleteMany([]);
+        $this->database->selectCollection('users')->deleteMany([]);
+    }
+
     #[When('I request my user info')]
     public function iRequestMyUserInfo(): void
     {
-        assert($this->authToken !== null, 'Must be logged in to request user info');
+        $headers = [];
+        if ($this->authToken !== null) {
+            $headers['Authorization'] = 'Bearer ' . $this->authToken;
+        }
 
-        $this->response = $this->makeGetRequest('/api/me', [
-            'Authorization' => 'Bearer ' . $this->authToken,
-        ]);
+        $this->response = $this->makeGetRequest('/api/me', $headers);
 
         if ($this->response->getStatusCode() === 200) {
             $content = self::getResponseContent($this->response);
@@ -223,12 +238,6 @@ final class UserContext implements Context
             assert(is_array($data));
             $this->userInfo = $data;
         }
-    }
-
-    #[When('I request my user info without authentication')]
-    public function iRequestMyUserInfoWithoutAuthentication(): void
-    {
-        $this->response = $this->makeGetRequest('/api/me');
     }
 
     #[Then('I should receive my user info with:')]
@@ -271,6 +280,12 @@ final class UserContext implements Context
     public function iShouldReceiveA401UnauthorizedError(): void
     {
         self::assertResponseStatusCode($this->response, 401, 'Unauthorized');
+    }
+
+    #[Then('I should receive a 404 Not Found error')]
+    public function iShouldReceiveA404NotFoundError(): void
+    {
+        self::assertResponseStatusCode($this->response, 404, 'Not Found');
     }
 
     private function registerWithData(string $email, string $dateOfBirth, string $displayName, string $password): void

--- a/tests/E2E/UserContext.php
+++ b/tests/E2E/UserContext.php
@@ -15,6 +15,7 @@ use MongoDB\Database;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * End-to-end context tests the full application stack with real HTTP requests.
@@ -28,6 +29,12 @@ final class UserContext implements Context
 
     private ?Response $response = null;
     private Database $database;
+    private ?string $authToken = null;
+
+    /**
+     * @var array<mixed, mixed>|null
+     */
+    private ?array $userInfo = null;
 
     public function __construct(
         private readonly KernelInterface $kernel,
@@ -162,6 +169,108 @@ final class UserContext implements Context
     public function loginShouldFailDueToValidationError(): void
     {
         self::assertResponseStatusCode($this->response, 422, 'Unprocessable Entity');
+    }
+
+    #[Given('a user registered with:')]
+    public function aUserRegisteredWith(TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+        $email = $data['email'];
+        $dateOfBirth = $data['dateOfBirth'];
+        $displayName = $data['displayName'];
+        $password = $data['password'];
+        assert(is_string($email) && is_string($dateOfBirth) && is_string($displayName) && is_string($password));
+
+        $this->registerWithData($email, $dateOfBirth, $displayName, $password);
+        self::assertResponseStatusCode($this->response, 201, 'Created (test setup)');
+
+        // Shutdown kernel to ensure services are fresh for next request
+        $this->kernel->shutdown();
+        $this->kernel->boot();
+
+        $this->response = null;
+    }
+
+    #[Given('I am logged in as :email with password :password')]
+    public function iAmLoggedInAsWithPassword(string $email, string $password): void
+    {
+        $this->iLogInWithEmailAndPassword($email, $password);
+        self::assertResponseStatusCode($this->response, 200, 'OK');
+
+        $content = self::getResponseContent($this->response);
+        $data = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+        assert(is_array($data) && isset($data['access_token']) && is_string($data['access_token']));
+
+        $this->authToken = $data['access_token'];
+
+        // Shutdown kernel to ensure services are fresh for next request
+        $this->kernel->shutdown();
+        $this->kernel->boot();
+    }
+
+    #[When('I request my user info')]
+    public function iRequestMyUserInfo(): void
+    {
+        assert($this->authToken !== null, 'Must be logged in to request user info');
+
+        $this->response = $this->makeGetRequest('/api/me', [
+            'Authorization' => 'Bearer ' . $this->authToken,
+        ]);
+
+        if ($this->response->getStatusCode() === 200) {
+            $content = self::getResponseContent($this->response);
+            $data = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+            assert(is_array($data));
+            $this->userInfo = $data;
+        }
+    }
+
+    #[When('I request my user info without authentication')]
+    public function iRequestMyUserInfoWithoutAuthentication(): void
+    {
+        $this->response = $this->makeGetRequest('/api/me');
+    }
+
+    #[Then('I should receive my user info with:')]
+    public function iShouldReceiveMyUserInfoWith(TableNode $table): void
+    {
+        self::assertResponseStatusCode($this->response, 200, 'OK');
+        assert($this->userInfo !== null, 'No user info received');
+
+        $expected = $table->getRowsHash();
+
+        if (isset($expected['email'])) {
+            Assert::same($this->userInfo['email'], $expected['email']);
+        }
+        if (isset($expected['displayName'])) {
+            Assert::same($this->userInfo['displayName'], $expected['displayName']);
+        }
+    }
+
+    #[Then('my user info should include a valid registration timestamp')]
+    public function myUserInfoShouldIncludeAValidRegistrationTimestamp(): void
+    {
+        assert($this->userInfo !== null, 'No user info received');
+        Assert::keyExists($this->userInfo, 'registeredAt');
+        Assert::string($this->userInfo['registeredAt']);
+
+        $registeredAt = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $this->userInfo['registeredAt']);
+        Assert::isInstanceOf($registeredAt, \DateTimeImmutable::class, 'registeredAt should be a valid ISO 8601 date');
+    }
+
+    #[Then('my user info should include my user ID')]
+    public function myUserInfoShouldIncludeMyUserId(): void
+    {
+        assert($this->userInfo !== null, 'No user info received');
+        Assert::keyExists($this->userInfo, 'id');
+        Assert::string($this->userInfo['id']);
+        Assert::notEmpty($this->userInfo['id']);
+    }
+
+    #[Then('I should receive a 401 Unauthorized error')]
+    public function iShouldReceiveA401UnauthorizedError(): void
+    {
+        self::assertResponseStatusCode($this->response, 401, 'Unauthorized');
     }
 
     private function registerWithData(string $email, string $dateOfBirth, string $displayName, string $password): void

--- a/tests/Integration/Infrastructure/Api/GetCurrentUserInfoEndpointTest.php
+++ b/tests/Integration/Infrastructure/Api/GetCurrentUserInfoEndpointTest.php
@@ -7,6 +7,8 @@ namespace App\Tests\Integration\Infrastructure\Api;
 use App\Application\MessageBus\QueryBusInterface;
 use App\Application\User\Query\GetUserInfoQuery;
 use App\Application\User\Query\UserInfo;
+use App\Domain\User\Exception\CouldNotFindUser;
+use App\Domain\User\ValueObject\UserId;
 use App\Infrastructure\Api\EventListener\TokenResponseHeadersListener;
 use App\Infrastructure\Api\Resource\CurrentUserResource;
 use App\Infrastructure\Api\State\GetCurrentUserInfoProvider;
@@ -32,6 +34,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 #[CoversClass(GetCurrentUserInfoProvider::class)]
 #[UsesClass(SecurityUser::class)]
 #[UsesClass(TokenResponseHeadersListener::class)]
+#[UsesClass(UserId::class)]
 final class GetCurrentUserInfoEndpointTest extends WebTestCase
 {
     use HttpHelper;
@@ -82,6 +85,21 @@ final class GetCurrentUserInfoEndpointTest extends WebTestCase
         self::assertSame('alice@example.com', $data['email']);
         self::assertSame('Alice', $data['displayName']);
         self::assertSame('2024-01-15T10:30:00+00:00', $data['registeredAt']);
+    }
+
+    public function testItReturns404WhenUserNoLongerExists(): void
+    {
+        $userId = '019412ab-cdef-7890-abcd-ef1234567890';
+
+        $this->queryBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->willThrowException(CouldNotFindUser::withId(UserId::fromString($userId)))
+        ;
+
+        $this->getJsonAsUser('/api/me', $userId);
+
+        self::assertResponseStatusCodeSame(404);
     }
 
     /**

--- a/tests/Integration/Infrastructure/Api/GetCurrentUserInfoEndpointTest.php
+++ b/tests/Integration/Infrastructure/Api/GetCurrentUserInfoEndpointTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Api;
+
+use App\Application\MessageBus\QueryBusInterface;
+use App\Application\User\Query\GetUserInfoQuery;
+use App\Application\User\Query\UserInfo;
+use App\Infrastructure\Api\EventListener\TokenResponseHeadersListener;
+use App\Infrastructure\Api\Resource\CurrentUserResource;
+use App\Infrastructure\Api\State\GetCurrentUserInfoProvider;
+use App\Infrastructure\Security\SecurityUser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Driving tests for the current user info API endpoint.
+ *
+ * These tests verify that the incoming HTTP adapter (API Platform provider)
+ * correctly transforms HTTP requests into queries and returns user info.
+ *
+ * Note: 401 Unauthorized when not authenticated is handled by Symfony's
+ * security firewall and tested via E2E tests.
+ *
+ * @internal
+ */
+#[CoversClass(CurrentUserResource::class)]
+#[CoversClass(GetCurrentUserInfoProvider::class)]
+#[UsesClass(SecurityUser::class)]
+#[UsesClass(TokenResponseHeadersListener::class)]
+final class GetCurrentUserInfoEndpointTest extends WebTestCase
+{
+    use HttpHelper;
+
+    private KernelBrowser $client;
+
+    /**
+     * @var MockObject&QueryBusInterface
+     */
+    private QueryBusInterface $queryBus;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+
+        $this->queryBus = $this->createMock(QueryBusInterface::class);
+        self::getContainer()->set(QueryBusInterface::class, $this->queryBus);
+    }
+
+    public function testItReturnsCurrentUserInfoWhenAuthenticated(): void
+    {
+        $userId = '019412ab-cdef-7890-abcd-ef1234567890';
+
+        $this->queryBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (GetUserInfoQuery $query) use ($userId): bool {
+                self::assertSame($userId, $query->userId);
+
+                return true;
+            }))
+            ->willReturn(new UserInfo(
+                id: $userId,
+                email: 'alice@example.com',
+                displayName: 'Alice',
+                registeredAt: '2024-01-15T10:30:00+00:00',
+            ))
+        ;
+
+        $this->getJsonAsUser('/api/me', $userId);
+
+        self::assertResponseStatusCodeSame(200);
+
+        $data = $this->getJsonResponse();
+
+        self::assertSame($userId, $data['id']);
+        self::assertSame('alice@example.com', $data['email']);
+        self::assertSame('Alice', $data['displayName']);
+        self::assertSame('2024-01-15T10:30:00+00:00', $data['registeredAt']);
+    }
+
+    /**
+     * Makes a GET request as an authenticated user.
+     *
+     * @param non-empty-string $userId
+     */
+    private function getJsonAsUser(string $uri, string $userId): void
+    {
+        $this->client->loginUser(new SecurityUser($userId));
+
+        $this->client->request('GET', $uri, server: [
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+    }
+}

--- a/tests/Integration/Infrastructure/Persistence/GetUserInfoContractTest.php
+++ b/tests/Integration/Infrastructure/Persistence/GetUserInfoContractTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Persistence;
+
+use App\Application\User\Query\GetUserInfo;
+use App\Application\User\Query\UserInfo;
+use App\Domain\User\Event\UserRegistered;
+use App\Domain\User\Exception\CouldNotFindUser;
+use App\Domain\User\ValueObject\UserId;
+use App\Infrastructure\Persistence\MongoDB\MongoGetUserInfo;
+use App\Infrastructure\Projection\UserProjection;
+use App\Tests\Integration\Infrastructure\MongoHelper;
+use App\Tests\UseCase\InMemoryGetUserInfo;
+use MongoDB\Collection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Contract tests for GetUserInfo implementations.
+ *
+ * All implementations of GetUserInfo must pass these tests
+ * to ensure consistent query behavior across adapters.
+ *
+ * @internal
+ */
+#[CoversClass(MongoGetUserInfo::class)]
+#[UsesClass(UserId::class)]
+#[UsesClass(UserProjection::class)]
+final class GetUserInfoContractTest extends TestCase
+{
+    use MongoHelper;
+
+    private const string TEST_DATE = '2025-01-15T10:30:00+00:00';
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        self::getMongoDatabase()->selectCollection('users')->drop();
+    }
+
+    #[\Override]
+    public static function tearDownAfterClass(): void
+    {
+        self::getMongoDatabase()->selectCollection('users')->drop();
+    }
+
+    /**
+     * @param callable(string): void $seeder
+     */
+    #[DataProvider('getterWithSeederProvider')]
+    public function testItThrowsExceptionForNonExistentUser(
+        GetUserInfo $getter,
+        callable $seeder,
+    ): void {
+        $seeder('existing@example.com');
+
+        $this->expectException(CouldNotFindUser::class);
+
+        $getter->byId(UserId::fromString(Uuid::v4()->toRfc4122()));
+    }
+
+    /**
+     * @param callable(string): void $seeder
+     */
+    #[DataProvider('getterWithSeederProvider')]
+    public function testItReturnsUserInfoForExistingUser(
+        GetUserInfo $getter,
+        callable $seeder,
+    ): void {
+        $email = 'info@example.com';
+        $expectedUserId = self::userIdFromEmail($email);
+
+        $seeder($email);
+
+        $result = $getter->byId(UserId::fromString($expectedUserId));
+
+        self::assertInstanceOf(UserInfo::class, $result);
+        self::assertSame($expectedUserId, $result->id);
+        self::assertSame($email, $result->email);
+        self::assertSame('Test User', $result->displayName);
+        self::assertSame(self::TEST_DATE, $result->registeredAt);
+    }
+
+    /**
+     * @param callable(string): void $seeder
+     */
+    #[DataProvider('getterWithSeederProvider')]
+    public function testItReturnsCorrectUserWhenMultipleUsersExist(
+        GetUserInfo $getter,
+        callable $seeder,
+    ): void {
+        $seeder('alice@example.com');
+        $seeder('bob@example.com');
+
+        $alice = $getter->byId(UserId::fromString(self::userIdFromEmail('alice@example.com')));
+        $bob = $getter->byId(UserId::fromString(self::userIdFromEmail('bob@example.com')));
+
+        self::assertSame('alice@example.com', $alice->email);
+        self::assertSame('bob@example.com', $bob->email);
+    }
+
+    /**
+     * @return iterable<string, array{GetUserInfo, callable(string): void}>
+     */
+    public static function getterWithSeederProvider(): iterable
+    {
+        $inMemoryGetter = new InMemoryGetUserInfo();
+
+        yield 'InMemory' => [
+            $inMemoryGetter,
+            self::createInMemorySeeder($inMemoryGetter),
+        ];
+
+        $mongoCollection = self::getMongoDatabase()->selectCollection('users');
+        $mongoCollection->drop();
+
+        yield 'MongoDB' => [
+            new MongoGetUserInfo($mongoCollection),
+            self::createMongoSeeder($mongoCollection),
+        ];
+    }
+
+    /**
+     * Generate a deterministic UUID from an email address.
+     */
+    private static function userIdFromEmail(string $email): string
+    {
+        return Uuid::v5(Uuid::fromString(Uuid::NAMESPACE_DNS), $email)->toRfc4122();
+    }
+
+    /**
+     * @return callable(string): void
+     */
+    private static function createInMemorySeeder(InMemoryGetUserInfo $getter): callable
+    {
+        return static function (string $email) use ($getter): void {
+            $getter->handleEvent(new UserRegistered(
+                id: self::userIdFromEmail($email),
+                email: $email,
+                dateOfBirth: '1990-05-15',
+                displayName: 'Test User',
+                hashedPassword: 'hashed_password',
+                occurredAt: new \DateTimeImmutable(self::TEST_DATE),
+            ));
+        };
+    }
+
+    /**
+     * @return callable(string): void
+     */
+    private static function createMongoSeeder(Collection $collection): callable
+    {
+        $projection = new UserProjection($collection);
+
+        return static function (string $email) use ($projection): void {
+            $projection->onUserRegistered(new UserRegistered(
+                id: self::userIdFromEmail($email),
+                email: $email,
+                dateOfBirth: '1990-05-15',
+                displayName: 'Test User',
+                hashedPassword: 'hashed_password',
+                occurredAt: new \DateTimeImmutable(self::TEST_DATE),
+            ));
+        };
+    }
+}

--- a/tests/Unit/Infrastructure/Security/JwtUserProviderTest.php
+++ b/tests/Unit/Infrastructure/Security/JwtUserProviderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Security;
+
+use App\Infrastructure\Security\JwtUserProvider;
+use App\Infrastructure\Security\SecurityUser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(JwtUserProvider::class)]
+#[UsesClass(SecurityUser::class)]
+final class JwtUserProviderTest extends TestCase
+{
+    private JwtUserProvider $provider;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->provider = new JwtUserProvider();
+    }
+
+    public function testItLoadsUserByIdentifier(): void
+    {
+        $userId = '019412ab-cdef-7890-abcd-ef1234567890';
+
+        $user = $this->provider->loadUserByIdentifier($userId);
+
+        self::assertInstanceOf(SecurityUser::class, $user);
+        self::assertSame($userId, $user->getUserIdentifier());
+    }
+
+    public function testItRefreshesSecurityUser(): void
+    {
+        $userId = '019412ab-cdef-7890-abcd-ef1234567890';
+        $originalUser = new SecurityUser($userId);
+
+        $refreshedUser = $this->provider->refreshUser($originalUser);
+
+        self::assertSame($originalUser, $refreshedUser);
+    }
+
+    public function testItThrowsWhenRefreshingUnsupportedUser(): void
+    {
+        $unsupportedUser = $this->createMock(UserInterface::class);
+
+        $this->expectException(UnsupportedUserException::class);
+
+        $this->provider->refreshUser($unsupportedUser);
+    }
+
+    public function testItSupportsSecurityUserClass(): void
+    {
+        self::assertTrue($this->provider->supportsClass(SecurityUser::class));
+    }
+
+    public function testItDoesNotSupportOtherClasses(): void
+    {
+        self::assertFalse($this->provider->supportsClass(UserInterface::class));
+        self::assertFalse($this->provider->supportsClass(\stdClass::class));
+    }
+}

--- a/tests/UseCase/InMemoryGetUserInfo.php
+++ b/tests/UseCase/InMemoryGetUserInfo.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\UseCase;
+
+use App\Application\User\Query\GetUserInfo;
+use App\Application\User\Query\UserInfo;
+use App\Domain\Common\Event\DomainEventInterface;
+use App\Domain\User\Event\UserRegistered;
+use App\Domain\User\Exception\CouldNotFindUser;
+use App\Domain\User\ValueObject\UserId;
+
+/**
+ * In-memory implementation of GetUserInfo for testing.
+ *
+ * Maintains a projection of user info from domain events.
+ *
+ * @internal Only to be used in tests
+ */
+final class InMemoryGetUserInfo implements GetUserInfo
+{
+    /**
+     * @var array<string, UserInfo> userId => UserInfo
+     */
+    private array $usersById = [];
+
+    public function handleEvent(DomainEventInterface $event): void
+    {
+        if ($event instanceof UserRegistered) {
+            $this->applyUserRegistered($event);
+        }
+    }
+
+    #[\Override]
+    public function byId(UserId $userId): UserInfo
+    {
+        $userInfo = $this->usersById[$userId->asString()] ?? null;
+
+        if ($userInfo === null) {
+            throw CouldNotFindUser::withId($userId);
+        }
+
+        return $userInfo;
+    }
+
+    private function applyUserRegistered(UserRegistered $event): void
+    {
+        assert($event->id !== '');
+        assert($event->email !== '');
+        assert($event->displayName !== '');
+
+        $this->usersById[$event->id] = new UserInfo(
+            id: $event->id,
+            email: $event->email,
+            displayName: $event->displayName,
+            registeredAt: $event->occurredAt->format(\DateTimeInterface::ATOM),
+        );
+    }
+}

--- a/tests/UseCase/TestContainer.php
+++ b/tests/UseCase/TestContainer.php
@@ -10,6 +10,8 @@ use App\Application\User\Command\RegisterUserCommand;
 use App\Application\User\Command\RegisterUserHandler;
 use App\Application\User\Query\FindUserAuthDataByEmailHandler;
 use App\Application\User\Query\FindUserAuthDataByEmailQuery;
+use App\Application\User\Query\GetUserInfoHandler;
+use App\Application\User\Query\GetUserInfoQuery;
 use Symfony\Component\Clock\MockClock;
 
 /**
@@ -29,10 +31,12 @@ final class TestContainer
         $passwordHasher = new FakePasswordHasher();
         $checkEmail = new InMemoryCheckEmail();
         $findUserAuthData = new InMemoryFindUserAuthData();
+        $getUserInfo = new InMemoryGetUserInfo();
 
         $this->eventStore = new InMemoryEventStore();
         $this->eventStore->addListener($checkEmail->handleEvent(...));
         $this->eventStore->addListener($findUserAuthData->handleEvent(...));
+        $this->eventStore->addListener($getUserInfo->handleEvent(...));
 
         $this->commandBus = new InMemoryCommandBus();
         $this->commandBus->register(
@@ -56,6 +60,10 @@ final class TestContainer
         $this->queryBus->register(
             FindUserAuthDataByEmailQuery::class,
             new FindUserAuthDataByEmailHandler($findUserAuthData),
+        );
+        $this->queryBus->register(
+            GetUserInfoQuery::class,
+            new GetUserInfoHandler($getUserInfo),
         );
     }
 }

--- a/tests/UseCase/UserContext.php
+++ b/tests/UseCase/UserContext.php
@@ -7,6 +7,8 @@ namespace App\Tests\UseCase;
 use App\Application\User\Command\LoginCommand;
 use App\Application\User\Command\RegisterUserCommand;
 use App\Application\User\Query\FindUserAuthDataByEmailQuery;
+use App\Application\User\Query\GetUserInfoQuery;
+use App\Application\User\Query\UserInfo;
 use App\Domain\User\Event\UserLoggedIn;
 use App\Domain\User\Exception\CouldNotAuthenticate;
 use App\Domain\User\Exception\CouldNotRegister;
@@ -32,6 +34,7 @@ final class UserContext implements Context
     private ?string $registeredUserId = null;
     private ?string $loggedInUserId = null;
     private ?\Throwable $caughtException = null;
+    private ?UserInfo $userInfo = null;
 
     public function __construct()
     {
@@ -207,6 +210,81 @@ final class UserContext implements Context
             \InvalidArgumentException::class,
             'Expected InvalidArgumentException to be thrown',
         );
+    }
+
+    #[Given('a user registered with:')]
+    public function aUserRegisteredWith(TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+        $email = $data['email'];
+        $dateOfBirth = $data['dateOfBirth'];
+        $displayName = $data['displayName'];
+        $password = $data['password'];
+        assert(is_string($email) && is_string($dateOfBirth) && is_string($displayName) && is_string($password));
+
+        $this->registerWithData($email, $dateOfBirth, $displayName, $password);
+    }
+
+    #[Given('I am logged in as :email with password :password')]
+    public function iAmLoggedInAsWithPassword(string $email, string $password): void
+    {
+        $this->iLogInWithEmailAndPassword($email, $password);
+        Assert::null($this->caughtException, 'Login should not have thrown an exception');
+        Assert::notNull($this->loggedInUserId, 'Expected to be logged in');
+    }
+
+    #[When('I request my user info')]
+    public function iRequestMyUserInfo(): void
+    {
+        Assert::notNull($this->loggedInUserId, 'Must be logged in to request user info');
+        assert($this->loggedInUserId !== '');
+
+        try {
+            $this->userInfo = $this->container->queryBus->dispatch(
+                new GetUserInfoQuery($this->loggedInUserId),
+            );
+        } catch (\Throwable $e) {
+            $this->caughtException = $e;
+        }
+    }
+
+    #[Then('I should receive my user info with:')]
+    public function iShouldReceiveMyUserInfoWith(TableNode $table): void
+    {
+        Assert::null($this->caughtException, 'Getting user info should not have thrown an exception');
+        Assert::notNull($this->userInfo, 'No user info was received');
+
+        $expected = $table->getRowsHash();
+
+        if (isset($expected['email'])) {
+            Assert::same($this->userInfo->email, $expected['email'], 'Email mismatch');
+        }
+        if (isset($expected['displayName'])) {
+            Assert::same($this->userInfo->displayName, $expected['displayName'], 'Display name mismatch');
+        }
+    }
+
+    #[Then('my user info should include a valid registration timestamp')]
+    public function myUserInfoShouldIncludeAValidRegistrationTimestamp(): void
+    {
+        Assert::notNull($this->userInfo, 'No user info was received');
+        Assert::notEmpty($this->userInfo->registeredAt, 'Registration timestamp is empty');
+
+        // Verify it's a valid ISO 8601 date
+        $parsed = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $this->userInfo->registeredAt);
+        Assert::isInstanceOf(
+            $parsed,
+            \DateTimeImmutable::class,
+            'Registration timestamp is not in valid ISO 8601 format',
+        );
+    }
+
+    #[Then('my user info should include my user ID')]
+    public function myUserInfoShouldIncludeMyUserId(): void
+    {
+        Assert::notNull($this->userInfo, 'No user info was received');
+        Assert::notNull($this->loggedInUserId, 'No logged in user ID');
+        Assert::same($this->userInfo->id, $this->loggedInUserId, 'User ID mismatch');
     }
 
     private function registerWithData(string $email, string $dateOfBirth, string $displayName, string $password): void


### PR DESCRIPTION
## Summary

- Implements GET `/api/me` endpoint that returns the authenticated user profile information
- Returns 401 Unauthorized when not authenticated
- Follows DDD/Hexagonal Architecture with CQRS pattern

Closes #18

## Test plan

- [x] Unit tests for JwtUserProvider
- [x] Contract tests for GetUserInfo (InMemory + MongoDB implementations)
- [x] Driving tests for GetCurrentUserInfoProvider
- [x] Behat use case tests for all scenarios
- [x] Behat E2E tests including 401 unauthorized case
- [x] 100% code coverage maintained
- [x] PHPStan, Deptrac, PHP-CS-Fixer all pass